### PR TITLE
fix: ensure deterministic random behavior in Team finalization

### DIFF
--- a/apps/team-splitter/src/team_splitter/roster.py
+++ b/apps/team-splitter/src/team_splitter/roster.py
@@ -30,10 +30,12 @@ class Player(DataClassJsonMixin):
 class Team:
     __name: str
     __players: List[Player]
+    __random: random.Random
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, rng: random.Random | None = None) -> None:
         self.__name = name
         self.__players = []
+        self.__random = rng if rng is not None else random.Random()
 
     @property
     def name(self) -> str:
@@ -61,7 +63,7 @@ class Team:
         finalized.append(f'Team {self.name}')
         goalies = [p.name for p in self.__players if p.role == Role.GOALIE]
         others = [p.name for p in self.__players if p.role != Role.GOALIE]
-        random.shuffle(others)
+        self.__random.shuffle(others)
         finalized.extend(goalies + others)
         return finalized
 

--- a/apps/team-splitter/src/team_splitter/team_splitter.py
+++ b/apps/team-splitter/src/team_splitter/team_splitter.py
@@ -52,7 +52,7 @@ class TeamSplitter:
         for p in players:
             grouped[p.role].append(p)
 
-        teams: List[Team] = [Team(TeamSplitter.TEAM_COLORS[colorIdx])
+        teams: List[Team] = [Team(TeamSplitter.TEAM_COLORS[colorIdx], self.__random)
                              for colorIdx in range(num_teams)]
 
         num_goalie_rounds = 0


### PR DESCRIPTION
- Add RNG parameter to Team constructor with default fallback
- Team now stores and uses instance-based Random for shuffling
- TeamSplitter passes its RNG to Team instances
- Ensures full determinism when seed is provided to TeamSplitter