### PR TITLE
feat: add team size balance validation

### DIFF
--- a/apps/team-splitter/src/team_splitter/team_splitter.py
+++ b/apps/team-splitter/src/team_splitter/team_splitter.py
@@ -47,6 +47,21 @@ class TeamSplitter:
         players_sorted = sorted(validated, key=lambda p: p.skill, reverse=True)
         return players_sorted
 
+    def __validate_team_balance(self, teams: List[Team]) -> None:
+        """Validate that team sizes differ by at most 1 player."""
+        if not teams:
+            return
+
+        team_sizes = [team.size() for team in teams]
+        min_size = min(team_sizes)
+        max_size = max(team_sizes)
+
+        if max_size - min_size > 1:
+            raise ValueError(
+                f'Team size imbalance: sizes range from {min_size} to {max_size}. '
+                f'Difference must not exceed 1 player.'
+            )
+
     def __split_into_teams(self, players: List[Player], num_teams: int) -> List[Team]:
         grouped: dict[Role, List[Player]] = defaultdict(list)
         for p in players:
@@ -81,6 +96,7 @@ class TeamSplitter:
                     break
                 teams[team_idx].add_player(non_goalies.pop(0))
 
+        self.__validate_team_balance(teams)
         return teams
 
     def __print_teams(self, teams: List[Team]) -> None:

--- a/apps/team-splitter/tests/test_splitting.py
+++ b/apps/team-splitter/tests/test_splitting.py
@@ -116,3 +116,16 @@ def test_no_seed_still_works(roster_epl: List[Player], player_list: str) -> None
     assert len(teams) == 2
     assert teams[0].size() + teams[1].size() == 16
     assert teams[0].role_count(Role.GOALIE) + teams[1].role_count(Role.GOALIE) == 2
+
+
+def test_team_size_difference_rule(roster_epl: List[Player], player_list: str) -> None:
+    """Test that team sizes differ by at most 1 player."""
+    splitter = TeamSplitter(roster_epl, seed=42)
+    teams = splitter.split_teams(player_list)
+
+    team_sizes = [team.size() for team in teams]
+    min_size = min(team_sizes)
+    max_size = max(team_sizes)
+
+    # Team size difference must not exceed 1
+    assert max_size - min_size <= 1


### PR DESCRIPTION
Add hard rule that team sizes must not differ by more than 1 player.

- Add __validate_team_balance() method to enforce the rule
- Raise ValueError if team size difference exceeds 1
- Add test_team_size_difference_rule() to verify enforcement
- Integrated validation after team splitting